### PR TITLE
tests: skip failing test.

### DIFF
--- a/DetoxSync/DetoxSyncTests/DTXSyncManagerSpec.m
+++ b/DetoxSync/DetoxSyncTests/DTXSyncManagerSpec.m
@@ -13,7 +13,7 @@
 #import "NSString+SyncStatus.h"
 #import "NSString+SyncResource.h"
 
-SpecBegin(DTXSyncManagerSpec)
+SpecBegin(DTXSyncManager)
 
 it(@"should report delayed perform selector busy resource", ^{
   DTXPerformSelectorAfterDelay();
@@ -51,7 +51,8 @@ it(@"should report dispatch queue busy resource", ^{
   }));
 });
 
-it(@"should report native timers busy resource", ^{
+// TODO: Investigate why this test is failing on iOS 16 and above.
+xit(@"should report native timers busy resource", ^{
   NSString *fireDate = DTXScheduleTimer(NO, 15);
 
   DTXSyncStatus *status = DTXAwaitStatus();


### PR DESCRIPTION
Skip failing test: `should report native timers busy resource`. This test fails on iOS 16 simulators.
See issue: https://github.com/wix/DetoxSync/issues/50