### PR TITLE
Revert "Ignore CADisplayLinks in DTXTimerSyncResource (#95)"

### DIFF
--- a/DetoxSync/DetoxSync/SyncResources/DTXTimerSyncResource.m
+++ b/DetoxSync/DetoxSync/SyncResources/DTXTimerSyncResource.m
@@ -90,20 +90,6 @@
 	return shared;
 }
 
-/// Check if a timer should be counted as busy (i.e., blocks synchronization)
-static BOOL _DTXShouldCountTimer(_DTXTimerTrampoline* trampoline)
-{
-	// Ignore all CADisplayLink timers - they're screen-refresh based, not event-based
-	// CADisplayLinks fire at 60/120 fps and don't represent actual work pending
-	if(trampoline.displayLink != nil)
-	{
-		return NO;
-	}
-
-	// All other timers (NSTimer, CFRunLoopTimer) count as busy
-	return YES;
-}
-
 /// Ugly hack for rare occasions where NSTimer gets released, but its associated objects are not released.
 static NSUInteger _DTXCleanTimersAndReturnCount(NSMutableSet* _timers, NSMutableArray<NSString*(^)(void)>* eventIdentifiers)
 {	
@@ -114,15 +100,8 @@ static NSUInteger _DTXCleanTimersAndReturnCount(NSMutableSet* _timers, NSMutable
 			[_timers removeObject:trampoline];
 		}
 	}
-
-	// Count only timers that should block synchronization (exclude CADisplayLink)
-	NSUInteger activeCount = 0;
-	for (_DTXTimerTrampoline* trampoline in _timers) {
-		if(_DTXShouldCountTimer(trampoline)) {
-			activeCount++;
-		}
-	}
-	return activeCount;
+	
+	return _timers.count;
 }
 
 - (void)clearTimerTrampolinesForCFRunLoop:(CFRunLoopRef)cfRunLoop


### PR DESCRIPTION
This reverts commit 3ec339781fec033f8ec64d61d339f7a0243b1d52.
The fix done in the previous commit is failing our tests because it takes out the CADisplayLink timers which are important for us.