### PR TITLE
DTXEnableVerboseSyncSystem Causes Apps to Hang on Garage Services Log in #4040

### DIFF
--- a/DetoxSync/DetoxSync/SyncManager/DTXSyncManager.m
+++ b/DetoxSync/DetoxSync/SyncManager/DTXSyncManager.m
@@ -240,6 +240,9 @@ static atomic_nstimeinterval _maximumAnimationDuration = ATOMIC_VAR_INIT(1.0);
 							syncResource:(DTXSyncResource*)resource
 								   block:(NSUInteger(NS_NOESCAPE ^)(void))block
 {
+	// Calling resource.jsonDescription inside outerBlock triggers dispatch operations
+	DTXBusyResource* jsonDesc = __detox_sync_enableVerboseSyncResourceLogging ? resource.jsonDescription : nil;
+	
 	dispatch_block_t outerBlock = ^ {
 		if([_registeredResources containsObject:resource] == NO)
 		{
@@ -251,7 +254,7 @@ static atomic_nstimeinterval _maximumAnimationDuration = ATOMIC_VAR_INIT(1.0);
 		NSUInteger busyCount = block();
 		if(previousBusyCount != busyCount)
 		{
-			DTXSyncResourceVerboseLog(@"%@", resource.jsonDescription);
+			DTXSyncResourceVerboseLog(@"%@", jsonDesc);
 
 			if(dtx_unlikely(_delegate != nil))
 			{
@@ -291,6 +294,9 @@ static atomic_nstimeinterval _maximumAnimationDuration = ATOMIC_VAR_INIT(1.0);
 									  syncResource:(DTXSyncResource*)resource
 											 block:(NSUInteger(NS_NOESCAPE ^)(void))block
 {
+	// Calling resource.jsonDescription inside outerBlock triggers dispatch operations
+	DTXBusyResource* jsonDesc = __detox_sync_enableVerboseSyncResourceLogging ? resource.jsonDescription : nil;
+	
 	dispatch_block_t outerBlock = ^ {
 		if([_registeredResources containsObject:resource] == NO)
 		{
@@ -302,7 +308,7 @@ static atomic_nstimeinterval _maximumAnimationDuration = ATOMIC_VAR_INIT(1.0);
 		NSUInteger busyCount = block();
 		if(previousBusyCount != busyCount)
 		{
-        DTXSyncResourceVerboseLog(@"%@", resource.jsonDescription);
+			DTXSyncResourceVerboseLog(@"%@", jsonDesc);
 
 			if(dtx_unlikely(_delegate != nil))
 			{


### PR DESCRIPTION
The Deadlock Chain:

We're on Thread A, calling performUpdateWithEventIdentifier
onQueue = false (we're NOT on _queue yet)
We capture jsonDesc = resource.jsonDescription ✅ (safe here)
We call __detox_sync_orig_dispatch_sync(_queue, outerBlock)
Now we're blocked, waiting for _queue to execute outerBlock
outerBlock starts executing on _queue
Inside the block, if we called resource.jsonDescription here (old code)
jsonDescription creates a string with [NSString stringWithFormat:@"%@", queue]
Formatting a dispatch_queue_t object triggers internal dispatch operations
Those operations might be something like: dispatch to a system queue to get queue metadata
Detox's fishhook spy intercepts those dispatch operations
When the system does dispatch_sync(some_tracked_queue, ...)
The spy wrapper calls addWorkBlock()
Which calls performUpdateWithEventIdentifier() (recursively!)
The recursive call tries to dispatch_sync to _queue
But _queue is already busy executing the first outerBlock
Deadlock! ❌