### PR TITLE
re-thinking the CAAnimation spy logic, crash during caanimation object release, support-case-#692

### DIFF
--- a/DetoxSync/DetoxSync/Spies/CAAnimation+DTXSpy.m
+++ b/DetoxSync/DetoxSync/Spies/CAAnimation+DTXSpy.m
@@ -12,105 +12,129 @@
 @import ObjectiveC;
 
 static const void* _DTXCAAnimationIsTrackingKey = &_DTXCAAnimationIsTrackingKey;
+static const void* _DTXCAAnimationProxyKey = &_DTXCAAnimationProxyKey;
 
-@interface _DTXCAAnimationDelegateHelper : NSObject @end
-@implementation _DTXCAAnimationDelegateHelper
+#pragma mark - Weak Reference Proxy
 
-- (void)__detox_sync_animationDidStart:(CAAnimation *)anim
+@interface _DTXAnimationDelegateProxy : NSObject <CAAnimationDelegate>
+@property (nonatomic, weak) id<CAAnimationDelegate> originalDelegate;
+@end
+
+@implementation _DTXAnimationDelegateProxy
+
+- (void)animationDidStart:(CAAnimation *)anim
 {
-	[anim __detox_sync_trackAnimation];
-	
-	[self __detox_sync_animationDidStart:anim];
+    [anim __detox_sync_trackAnimation];
+    
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:@selector(animationDidStart:)]) {
+        [delegate animationDidStart:anim];
+    }
 }
 
-- (void)__detox_sync_animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
+- (void)animationDidStop:(CAAnimation *)anim finished:(BOOL)flag
 {
-	[self __detox_sync_animationDidStop:anim finished:flag];
-	
-	[anim __detox_sync_untrackAnimation];
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:@selector(animationDidStop:finished:)]) {
+        [delegate animationDidStop:anim finished:flag];
+    }
+    
+    [anim __detox_sync_untrackAnimation];
+}
+
+// Forward any other delegate methods
+- (BOOL)respondsToSelector:(SEL)aSelector
+{
+    if (aSelector == @selector(animationDidStart:) ||
+        aSelector == @selector(animationDidStop:finished:)) {
+        return YES;
+    }
+    
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [delegate respondsToSelector:aSelector];
+    }
+    return [super respondsToSelector:aSelector];
+}
+
+- (id)forwardingTargetForSelector:(SEL)aSelector
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:aSelector]) {
+        return delegate;
+    }
+    return [super forwardingTargetForSelector:aSelector];
 }
 
 @end
 
+#pragma mark - CAAnimation Extension
+
 @interface CAAnimation ()
-
 - (BOOL)_setCARenderAnimation:(void*)arg1 layer:(id)arg2;
-
 @end
 
 @implementation CAAnimation (DTXSpy)
 
 - (BOOL)__detox_sync_isTracking
 {
-	return [objc_getAssociatedObject(self, _DTXCAAnimationIsTrackingKey) boolValue];
+    return [objc_getAssociatedObject(self, _DTXCAAnimationIsTrackingKey) boolValue];
 }
 
 - (void)__detox_sync_setTracking:(BOOL)tracking
 {
-	objc_setAssociatedObject(self, _DTXCAAnimationIsTrackingKey, @(tracking), OBJC_ASSOCIATION_RETAIN);
+    objc_setAssociatedObject(self, _DTXCAAnimationIsTrackingKey, @(tracking), OBJC_ASSOCIATION_RETAIN);
 }
 
 - (void)__detox_sync_trackAnimation
 {
-	[self __detox_sync_untrackAnimation];
-	
-	[DTXUISyncResource.sharedInstance trackCAAnimation:self];
-	[self __detox_sync_setTracking:YES];
+    [self __detox_sync_untrackAnimation];
+    
+    [DTXUISyncResource.sharedInstance trackCAAnimation:self];
+    [self __detox_sync_setTracking:YES];
 }
 
 - (void)__detox_sync_untrackAnimation
 {
-	if(self.__detox_sync_isTracking == YES)
-	{
-		[DTXUISyncResource.sharedInstance untrackCAAnimation:self];
-		[self __detox_sync_setTracking:NO];
-	}
+    if(self.__detox_sync_isTracking == YES)
+    {
+        [DTXUISyncResource.sharedInstance untrackCAAnimation:self];
+        [self __detox_sync_setTracking:NO];
+    }
 }
 
 + (void)load
 {
-	@autoreleasepool
-	{
-		DTXSwizzleMethod(CAAnimation.class, @selector(setDelegate:), @selector(__detox_sync_setDelegate:), NULL);
-	}
-}
-
-- (void)__detox_sync_prepareDelegateIfNeeded:(id<CAAnimationDelegate>)delegate
-{
-	Method mmm = class_getInstanceMethod(delegate.class, NSSelectorFromString(@"__detox_sync_canary"));
-	if(mmm != NULL)
-	{
-		return;
-	}
-	
-	NSError* error;
-	
-	Method m2_helper = class_getInstanceMethod(_DTXCAAnimationDelegateHelper.class, @selector(__detox_sync_animationDidStart:));
-	if(class_getInstanceMethod(delegate.class, @selector(animationDidStart:)) == NULL)
-	{
-		class_addMethod(delegate.class, @selector(animationDidStart:), imp_implementationWithBlock(^(id _self, id anim) { }), method_getTypeEncoding(m2_helper));
-	}
-	class_addMethod(delegate.class, @selector(__detox_sync_animationDidStart:), method_getImplementation(m2_helper), method_getTypeEncoding(m2_helper));
-	
-	DTXSwizzleMethod(delegate.class, @selector(animationDidStart:), @selector(__detox_sync_animationDidStart:), &error);
-	
-	m2_helper = class_getInstanceMethod(_DTXCAAnimationDelegateHelper.class, @selector(__detox_sync_animationDidStop:finished:));
-	if(class_getInstanceMethod(delegate.class, @selector(animationDidStop:finished:)) == NULL)
-	{
-		class_addMethod(delegate.class, @selector(animationDidStop:finished:), imp_implementationWithBlock(^(id _self, id anim) { }), method_getTypeEncoding(m2_helper));
-	}
-	class_addMethod(delegate.class, @selector(__detox_sync_animationDidStop:finished:), method_getImplementation(m2_helper), method_getTypeEncoding(m2_helper));
-	
-	DTXSwizzleMethod(delegate.class, @selector(animationDidStop:finished:), @selector(__detox_sync_animationDidStop:finished:), &error);
-	
-	class_addMethod(delegate.class, NSSelectorFromString(@"__detox_sync_canary"), imp_implementationWithBlock(^ (id _self) { }), "v8@0:4");
+    @autoreleasepool
+    {
+        DTXSwizzleMethod(CAAnimation.class, @selector(setDelegate:), @selector(__detox_sync_setDelegate:), NULL);
+    }
 }
 
 - (void)__detox_sync_setDelegate:(id<CAAnimationDelegate>)delegate
 {
-	[self __detox_sync_prepareDelegateIfNeeded:delegate];
-	
-	[self __detox_sync_setDelegate:delegate];
+    if (delegate == nil) {
+        // Clear the proxy reference
+        objc_setAssociatedObject(self, _DTXCAAnimationProxyKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+        [self __detox_sync_setDelegate:nil];
+        return;
+    }
+    
+    // Don't wrap if already a proxy
+    if ([delegate isKindOfClass:[_DTXAnimationDelegateProxy class]]) {
+        [self __detox_sync_setDelegate:delegate];
+        return;
+    }
+    
+    // Create proxy with weak reference to original delegate
+    _DTXAnimationDelegateProxy *proxy = [[_DTXAnimationDelegateProxy alloc] init];
+    proxy.originalDelegate = delegate;
+    
+    // Store proxy with strong reference on the animation (so it stays alive)
+    objc_setAssociatedObject(self, _DTXCAAnimationProxyKey, proxy, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    
+    // Set proxy as the delegate
+    [self __detox_sync_setDelegate:proxy];
 }
 
 @end

--- a/DetoxSync/DetoxSync/Spies/CAAnimation+DTXSpy.m
+++ b/DetoxSync/DetoxSync/Spies/CAAnimation+DTXSpy.m
@@ -16,11 +16,21 @@ static const void* _DTXCAAnimationProxyKey = &_DTXCAAnimationProxyKey;
 
 #pragma mark - Weak Reference Proxy
 
-@interface _DTXAnimationDelegateProxy : NSObject <CAAnimationDelegate>
+@interface _DTXAnimationDelegateProxy : NSProxy <CAAnimationDelegate>
 @property (nonatomic, weak) id<CAAnimationDelegate> originalDelegate;
+@property (nonatomic, strong) Class originalClass;
 @end
 
 @implementation _DTXAnimationDelegateProxy
+
+- (instancetype)initWithDelegate:(id<CAAnimationDelegate>)delegate
+{
+    _originalDelegate = delegate;
+    _originalClass = [delegate class];
+    return self;
+}
+
+#pragma mark - CAAnimationDelegate methods (intercepted)
 
 - (void)animationDidStart:(CAAnimation *)anim
 {
@@ -42,7 +52,54 @@ static const void* _DTXCAAnimationProxyKey = &_DTXCAAnimationProxyKey;
     [anim __detox_sync_untrackAnimation];
 }
 
-// Forward any other delegate methods
+#pragma mark - Transparent proxy methods (mimic original delegate identity)
+
+- (Class)class
+{
+    return self.originalClass ?: [super class];
+}
+
+- (BOOL)isKindOfClass:(Class)aClass
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [delegate isKindOfClass:aClass];
+    }
+    return self.originalClass ? [self.originalClass isSubclassOfClass:aClass] : NO;
+}
+
+- (BOOL)isMemberOfClass:(Class)aClass
+{
+    return self.originalClass == aClass;
+}
+
+- (BOOL)isEqual:(id)object
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [delegate isEqual:object];
+    }
+    return self == object;
+}
+
+- (NSUInteger)hash
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [delegate hash];
+    }
+    return (NSUInteger)self;
+}
+
+- (BOOL)conformsToProtocol:(Protocol *)aProtocol
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [delegate conformsToProtocol:aProtocol];
+    }
+    return self.originalClass ? class_conformsToProtocol(self.originalClass, aProtocol) : NO;
+}
+
 - (BOOL)respondsToSelector:(SEL)aSelector
 {
     if (aSelector == @selector(animationDidStart:) ||
@@ -54,25 +111,65 @@ static const void* _DTXCAAnimationProxyKey = &_DTXCAAnimationProxyKey;
     if (delegate) {
         return [delegate respondsToSelector:aSelector];
     }
-    return [super respondsToSelector:aSelector];
+    return NO;
+}
+
+#pragma mark - NSProxy forwarding
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)sel
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [(NSObject *)delegate methodSignatureForSelector:sel];
+    }
+    return [NSMethodSignature signatureWithObjCTypes:"v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)invocation
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate && [delegate respondsToSelector:invocation.selector]) {
+        [invocation invokeWithTarget:delegate];
+    }
 }
 
 - (id)forwardingTargetForSelector:(SEL)aSelector
 {
+    // Don't forward the methods we intercept
+    if (aSelector == @selector(animationDidStart:) ||
+        aSelector == @selector(animationDidStop:finished:)) {
+        return nil;
+    }
+    
     id<CAAnimationDelegate> delegate = self.originalDelegate;
     if (delegate && [delegate respondsToSelector:aSelector]) {
         return delegate;
     }
-    return [super forwardingTargetForSelector:aSelector];
+    return nil;
+}
+
+- (NSString *)description
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [(NSObject *)delegate description];
+    }
+    NSString *className = self.originalClass ? NSStringFromClass(self.originalClass) : @"_DTXAnimationDelegateProxy";
+    return [NSString stringWithFormat:@"<%@: %p (delegate deallocated)>", className, self];
+}
+
+- (NSString *)debugDescription
+{
+    id<CAAnimationDelegate> delegate = self.originalDelegate;
+    if (delegate) {
+        return [(NSObject *)delegate debugDescription];
+    }
+    return [self description];
 }
 
 @end
 
 #pragma mark - CAAnimation Extension
-
-@interface CAAnimation ()
-- (BOOL)_setCARenderAnimation:(void*)arg1 layer:(id)arg2;
-@end
 
 @implementation CAAnimation (DTXSpy)
 
@@ -121,14 +218,13 @@ static const void* _DTXCAAnimationProxyKey = &_DTXCAAnimationProxyKey;
     }
     
     // Don't wrap if already a proxy
-    if ([delegate isKindOfClass:[_DTXAnimationDelegateProxy class]]) {
+    if ([object_getClass(delegate) isSubclassOfClass:[_DTXAnimationDelegateProxy class]]) {
         [self __detox_sync_setDelegate:delegate];
         return;
     }
     
     // Create proxy with weak reference to original delegate
-    _DTXAnimationDelegateProxy *proxy = [[_DTXAnimationDelegateProxy alloc] init];
-    proxy.originalDelegate = delegate;
+    _DTXAnimationDelegateProxy *proxy = [[_DTXAnimationDelegateProxy alloc] initWithDelegate:delegate];
     
     // Store proxy with strong reference on the animation (so it stays alive)
     objc_setAssociatedObject(self, _DTXCAAnimationProxyKey, proxy, OBJC_ASSOCIATION_RETAIN_NONATOMIC);


### PR DESCRIPTION
The problem was that the self object (delegate) was no longer valid when calling the origional method and thus crashed.
There was no way to check this validity.

***********************************
The old approach:
1. __detox_sync_prepareDelegateIfNeeded: (lines 78-107) dynamically injects methods into the delegate's class at runtime
2. It copies the implementation from _DTXCAAnimationDelegateHelper and swizzles animationDidStop:finished:
3. When the animation completes, the swizzled method is called on the delegate - but the delegate may be deallocated

**Original: 1-to-Many (Class-level swizzling)**
───────────────────
UIViewAnimationBlockDelegate CLASS
(modified once, affects ALL instances) 

animationDidStart: ──swizzled──▶ __detox_sync_animationDidStart:
animationDidStop:  ──swizzled──▶ __detox_sync_animationDidStop:

delegate A   (instance)   ─▶ Animation1
delegate B   (instance)   ─▶ Animation2
delegate C   (instance)   ─▶ Animation3
  
* Problem: If delegate B is deallocated, Animation2's callbacks crash because the swizzled method still tries to call [self ...] on a dead object.


***********************************
The new approach:
1. __detox_sync_setDelegate: (lines 114-138) creates a new _DTXAnimationDelegateProxy instance for each animation
2. The proxy stores a weak reference to the original delegate and becomes the animation's actual delegate
3. When the animation completes, the proxy's animationDidStop:finished: is called - it checks if the original delegate is still alive before forwarding

**New: 1-to-1 (Instance-level proxy)**
───────────────────
Animation1 delegate ─▶ Proxy 1 origionalDelegate (weak) ─▶ delegate A (origional)
Animation2 delegate ─▶ Proxy 2 origionalDelegate (weak) ─▶ delegate B (DEALLOC!)
Animation3 delegate ─▶ Proxy 3 origionalDelegate (weak) ─▶ delegate C (origional)

Safety: If delegate B is deallocated:
Proxy 2's originalDelegate becomes nil (weak reference)
Proxy 2's animationDidStop: checks if (delegate) → false → no call → no crash
Animations 1 and 3 are unaffected
