### PR TITLE
fix(ios/DetoxSync): make URLSession network untrack thread-safe and idempotent

### DIFF
--- a/DetoxSync/DetoxSync/Spies/NSURLSession+DTXSpy.m
+++ b/DetoxSync/DetoxSync/Spies/NSURLSession+DTXSpy.m
@@ -128,7 +128,7 @@
 	id syncCompletionHandler = completionHandler == nil ? nil : ^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 		completionHandler(data, response, error);
 		
-		NSURLSessionDataTask* task = weakTask;
+		NSURLSessionDataTask* task = weakTask ?: rv;
 		if(task != nil)
 		{
 			[task __detox_sync_untrackTask];
@@ -149,7 +149,7 @@
 	id syncCompletionHandler = completionHandler == nil ? nil : ^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 		completionHandler(data, response, error);
 		
-		NSURLSessionDataTask* task = weakTask;
+		NSURLSessionDataTask* task = weakTask ?: rv;
 		if(task != nil)
 		{
 			[task __detox_sync_untrackTask];

--- a/DetoxSync/DetoxSync/Spies/NSURLSession+DTXSpy.m
+++ b/DetoxSync/DetoxSync/Spies/NSURLSession+DTXSpy.m
@@ -20,6 +20,7 @@
 	SEL cmd = @selector(URLSession:dataTask:didReceiveResponse:completionHandler:);
 	if([superclass instancesRespondToSelector:cmd])
 	{
+		__weak NSURLSessionDataTask* weakDataTask = dataTask;
 		id detoxSyncCompletionHandler = ^(NSURLSessionResponseDisposition disposition) {
 			completionHandler(disposition);
 			
@@ -27,8 +28,14 @@
 			switch (disposition) {
 				case NSURLSessionResponseBecomeDownload:
 				case NSURLSessionResponseBecomeStream:
-					[dataTask __detox_sync_untrackTask];
+				{
+					NSURLSessionDataTask* task = weakDataTask;
+					if(task != nil)
+					{
+						[task __detox_sync_untrackTask];
+					}
 					break;
+				}
 				default:
 					break;
 			}
@@ -116,14 +123,20 @@
 - (NSURLSessionDataTask *)__detox_sync_dataTaskWithRequest:(NSURLRequest *)request completionHandler:(void (^)(NSData * _Nullable, NSURLResponse * _Nullable, NSError * _Nullable))completionHandler
 {
 	__block NSURLSessionDataTask* rv;
+	__weak NSURLSessionDataTask* weakTask;
 	
 	id syncCompletionHandler = completionHandler == nil ? nil : ^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 		completionHandler(data, response, error);
 		
-		[rv __detox_sync_untrackTask];
+		NSURLSessionDataTask* task = weakTask;
+		if(task != nil)
+		{
+			[task __detox_sync_untrackTask];
+		}
 	};
 	
 	rv = [self __detox_sync_dataTaskWithRequest:request completionHandler:syncCompletionHandler];
+	weakTask = rv;
 	
 	return rv;
 }
@@ -131,14 +144,20 @@
 - (NSURLSessionDataTask *)__detox_sync_dataTaskWithURL:(NSURL *)url completionHandler:(void (^)(NSData * _Nullable, NSURLResponse * _Nullable, NSError * _Nullable))completionHandler
 {
 	__block NSURLSessionDataTask* rv;
+	__weak NSURLSessionDataTask* weakTask;
 	
 	id syncCompletionHandler = completionHandler == nil ? nil : ^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 		completionHandler(data, response, error);
 		
-		[rv __detox_sync_untrackTask];
+		NSURLSessionDataTask* task = weakTask;
+		if(task != nil)
+		{
+			[task __detox_sync_untrackTask];
+		}
 	};
 	
 	rv = [self __detox_sync_dataTaskWithURL:url completionHandler:syncCompletionHandler];
+	weakTask = rv;
 	
 	return rv;
 }

--- a/DetoxSync/DetoxSync/Spies/NSURLSessionTask+DTXSpy.m
+++ b/DetoxSync/DetoxSync/Spies/NSURLSessionTask+DTXSpy.m
@@ -77,9 +77,16 @@ static const void* _DTXNetworkTaskSRKey = &_DTXNetworkTaskSRKey;
 
 - (void)__detox_sync_untrackTask
 {
-	id<DTXSingleEvent> sr = objc_getAssociatedObject(self, _DTXNetworkTaskSRKey);
-	[sr endTracking];
-	objc_setAssociatedObject(self, _DTXNetworkTaskSRKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	@synchronized(self) {
+		id<DTXSingleEvent> sr = objc_getAssociatedObject(self, _DTXNetworkTaskSRKey);
+		if(sr == nil)
+		{
+			return;
+		}
+		
+		objc_setAssociatedObject(self, _DTXNetworkTaskSRKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+		[sr endTracking];
+	}
 }
 
 - (void)__detox_sync_connection:(id)arg1 didFinishLoadingWithError:(id)arg2;


### PR DESCRIPTION
## Summary

Fixes an iOS **Signal 11 (SIGSEGV)** crash in DetoxSync when tearing down tracked `NSURLSession` tasks. The crash appeared across many unrelated e2e tests (bookings, classes, BSM, member flows) with the same stack: `NSURLSessionTask(DTXSpy) __detox_sync_untrackTask` → CFNetwork → Detox-wrapped background `dispatch` block (and in some cases `endTracking` → `_Block_copy`).

## Problem

When a network request completes, DetoxSync can untrack the same task from **multiple paths**, often on **different threads**:

- `URLSession:task:didCompleteWithError:` (delegate proxy)
- Completion-handler wrapper around `dataTaskWithRequest:completionHandler:`
- `connection:didFinishLoadingWithError:` when the session has no delegate
- CFNetwork internal completion work scheduled on a tracked background queue

`__detox_sync_untrackTask` was not idempotent:

1. No synchronization — two threads could both read the same associated sync resource and call `endTracking`.
2. The associated object was cleared **after** `endTracking`, widening the race window.
3. Completion handlers captured the task via `__block` and called untrack after async completion, which could run after the task was deallocated.

That led to use-after-free of the sync resource (crash during `_Block_copy` / `performUpdate`) or invalid messaging (null / garbage `self`).

## Solution

### `NSURLSessionTask+DTXSpy.m`

- Guard `__detox_sync_untrackTask` with `@synchronized(self)`.
- Return immediately if no sync resource is associated.
- **Clear the association before** `[sr endTracking]` so concurrent callers are no-ops.

### `NSURLSession+DTXSpy.m`

- In completion-handler wrappers, use `__weak` / strong task references instead of `__block` task pointers when calling untrack.
- Apply the same weak-task pattern in `didReceiveResponse` when upgrading to download/stream.

## Notes for reviewers

- No change to when requests **start** being tracked (`resume` / URL blacklist unchanged).
- Android failures in the same nightly run were mostly assertion/UI issues; this PR targets **iOS native DetoxSync** only.
- Downstream: after merge and release, Wix infra needs a `detox` / `@wix/detox` bump for CI to pick up the fix.
